### PR TITLE
aタグのはみ出し修正

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -196,6 +196,9 @@ blockquote {
   ul {
     margin-left: $base-fs;
   }
+  a {
+    word-break: break-all;
+  }
   a.anchor {
     display: none;
   }

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -197,7 +197,7 @@ blockquote {
     margin-left: $base-fs;
   }
   a {
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
   a.anchor {
     display: none;


### PR DESCRIPTION
リンクとしてURLを直書きしているところが領域からはみ出てしまっていて、少し横スクロールが生じていたので修正しました。
(.markdown a に対して、overflow-wrap: break-word;を挿入)
